### PR TITLE
Update CalendarView.java

### DIFF
--- a/calendarview/src/main/java/com/haibin/calendarview/CalendarView.java
+++ b/calendarview/src/main/java/com/haibin/calendarview/CalendarView.java
@@ -1212,7 +1212,7 @@ public class CalendarView extends FrameLayout {
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         int height = MeasureSpec.getSize(heightMeasureSpec);
         if (mDelegate == null ||
-                !mDelegate.isFullScreenCalendar()) {
+                !mDelegate.isFullScreenCalendar() || height == 0) {
             super.onMeasure(widthMeasureSpec, heightMeasureSpec);
             return;
         }


### PR DESCRIPTION
[fix] opanA33 Android5.1.1下 , onMeasure的height为0,显示不了月视图