### PR TITLE
Update CalendarViewDelegate.java

### DIFF
--- a/calendarview/src/main/java/com/haibin/calendarview/CalendarViewDelegate.java
+++ b/calendarview/src/main/java/com/haibin/calendarview/CalendarViewDelegate.java
@@ -441,9 +441,6 @@ final class CalendarViewDelegate {
                 CalendarUtil.dipToPx(context, 0));
 
         mSchemeText = array.getString(R.styleable.CalendarView_scheme_text);
-        if (TextUtils.isEmpty(mSchemeText)) {
-            mSchemeText = "记";
-        }
 
         mMonthViewScrollable = array.getBoolean(R.styleable.CalendarView_month_view_scrollable, true);
         mWeekViewScrollable = array.getBoolean(R.styleable.CalendarView_week_view_scrollable, true);


### PR DESCRIPTION
删除默认的 `mSchemeText `值（“记”）
否则会导致调用 `setSchemeDate(map)` 方法传递参数 map 中包含空的 scheme，会默认使用 “记” 代替