### PR TITLE
fix:不使用CalendarLayout调用scrollToCalendar/current 导致crash

### DIFF
--- a/calendarview/src/main/java/com/haibin/calendarview/WeekViewPager.java
+++ b/calendarview/src/main/java/com/haibin/calendarview/WeekViewPager.java
@@ -196,8 +196,10 @@ public final class WeekViewPager extends ViewPager {
         if (mDelegate.mCalendarSelectListener != null && invokeListener) {
             mDelegate.mCalendarSelectListener.onCalendarSelect(calendar, false);
         }
-        int i = CalendarUtil.getWeekFromDayInMonth(calendar, mDelegate.getWeekStart());
-        mParentLayout.updateSelectWeek(i);
+        if (mParentLayout != null) {
+            int i = CalendarUtil.getWeekFromDayInMonth(calendar, mDelegate.getWeekStart());
+            mParentLayout.updateSelectWeek(i);
+        }
     }
 
     /**
@@ -229,8 +231,11 @@ public final class WeekViewPager extends ViewPager {
         if (getVisibility() == VISIBLE) {
             mDelegate.mInnerListener.onWeekDateSelected(mDelegate.getCurrentDay(), false);
         }
-        int i = CalendarUtil.getWeekFromDayInMonth(mDelegate.getCurrentDay(), mDelegate.getWeekStart());
-        mParentLayout.updateSelectWeek(i);
+
+        if (mParentLayout != null) {
+            int i = CalendarUtil.getWeekFromDayInMonth(mDelegate.getCurrentDay(), mDelegate.getWeekStart());
+            mParentLayout.updateSelectWeek(i);
+        }
     }
 
     /**


### PR DESCRIPTION
如果不使用calendarLayout，在周视图中使用scrollToCalendar()或scrollToCurrent()会导致crash。
