### PR TITLE
fix: scrollToCalendar MonthView shown weeks correctly.

### DIFF
--- a/calendarview/src/main/java/com/haibin/calendarview/MonthViewPager.java
+++ b/calendarview/src/main/java/com/haibin/calendarview/MonthViewPager.java
@@ -318,6 +318,11 @@ public final class MonthViewPager extends ViewPager {
         }
         setCurrentItem(position, smoothScroll);
 
+        updateMonthViewHeight(calendar.getYear(), calendar.getMonth());
+        ViewGroup.LayoutParams params = getLayoutParams();
+        params.height = mCurrentViewHeight;
+        setLayoutParams(params);
+
         BaseMonthView view = findViewWithTag(position);
         if (view != null) {
             view.setSelectedCalendar(mDelegate.mIndexCalendar);


### PR DESCRIPTION
修复scrollToCalendar 月份视图完整显示所有周